### PR TITLE
boole fork config for ssv

### DIFF
--- a/main.star
+++ b/main.star
@@ -120,7 +120,7 @@ def run(plan, args):
     # Start up the ssv nodes
     for _ in range(0, ssv_node_count):
         is_exporter = False
-        config = ssv_node.generate_config(plan, node_index, cl_url, el_ws, private_keys[node_index], enr, is_exporter)
+        config = ssv_node.generate_config(plan, node_index, cl_url, el_ws, private_keys[node_index], enr, is_exporter, args)
         plan.print("generated SSV node config artifact: " + json.indent(json.encode(config)))
 
         plan.print("starting SSV node with index: " + str(node_index))

--- a/nodes/ssv/config.yml.tmpl
+++ b/nodes/ssv/config.yml.tmpl
@@ -18,6 +18,9 @@ ssv:
     RegistrySyncOffset: "{{ .RegistrySyncOffset }}"
     RegistryContractAddr: "{{ .RegistryContractAddr }}"
     DiscoveryProtocolID: "{{ .DiscoveryProtocolID }}"
+    Forks:
+      gaslimit36: 0
+      boole: {{ .BooleEpoch }}
 OperatorPrivateKey: "{{ .OperatorPrivateKey }}"
 SSVAPIPort: {{ .SSVAPIPort }}
 Exporter: "{{ .Exporter }}"

--- a/nodes/ssv/node.star
+++ b/nodes/ssv/node.star
@@ -16,7 +16,9 @@ def generate_config(
         operator_private_key,
         enr,
         is_exporter,
+        args,
 ):
+    boole_epoch = args.get("boole_epoch", 1 << 63)
     discovery = ""
     if enr == "":
         discovery = "mdns"
@@ -41,7 +43,8 @@ def generate_config(
         Exporter=is_exporter,
         SSVAPIPort=SSV_API_PORT,
         MetricsAPIPort=SSV_METRICS_PORT,
-        EnableTraces=True
+        EnableTraces=True,
+        BooleEpoch=boole_epoch,
     )
 
     plan.print(

--- a/params.yaml
+++ b/params.yaml
@@ -44,6 +44,9 @@ network:
 monitor:
   enabled: false
 
+# Boole fork activation epoch (shared by both SSV and Anchor nodes)
+boole_epoch: 3
+
 nodes:
   ssv:
     count: 2


### PR DESCRIPTION
added support for setting boole epoch for ssv nodes. you can use `params.yaml` to set the boole fork to apply to both anchor and ssv nodes now. 

Note that ssv nodes don't work with anchor nodes when `minimal` preset is used, so you'll want to default to mainnet preset during testing

Figured I'd make this PR to your branch so that when you upstream to `ssv-mini`, it'll have everything 🤙 