### PR TITLE
fix: resolve CI port binding and cleanup issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,13 @@ default: run-with-prepare
 # Run with prepare: Downloads latest repos (ssv stage, anchor unstable, ethereum2-monitor main) and builds Docker images
 .PHONY: run-with-prepare
 run-with-prepare: prepare
+	kurtosis clean -a || true
 	kurtosis run --verbosity DETAILED --enclave ${ENCLAVE_NAME} . "$$(cat ${PARAMS_FILE})"
 
 # Run without prepare: Uses existing local repos and Docker images (for custom branches/versions)
 .PHONY: run
 run:
+	kurtosis clean -a || true
 	kurtosis run --verbosity DETAILED --enclave ${ENCLAVE_NAME} . "$$(cat ${PARAMS_FILE})"
 
 # Reset with prepare: Clean and run with latest repos and fresh Docker images

--- a/main.star
+++ b/main.star
@@ -120,7 +120,7 @@ def run(plan, args):
     # Start up the ssv nodes
     for _ in range(0, ssv_node_count):
         is_exporter = False
-        config = ssv_node.generate_config(plan, node_index, cl_url, el_ws, private_keys[node_index], enr, is_exporter)
+        config = ssv_node.generate_config(plan, node_index, cl_url, el_ws, private_keys[node_index], enr, is_exporter, args)
         plan.print("generated SSV node config artifact: " + json.indent(json.encode(config)))
 
         plan.print("starting SSV node with index: " + str(node_index))

--- a/nodes/ssv/config.yml.tmpl
+++ b/nodes/ssv/config.yml.tmpl
@@ -18,6 +18,9 @@ ssv:
     RegistrySyncOffset: "{{ .RegistrySyncOffset }}"
     RegistryContractAddr: "{{ .RegistryContractAddr }}"
     DiscoveryProtocolID: "{{ .DiscoveryProtocolID }}"
+    Forks:
+      gaslimit36: 0
+      boole: {{ .BooleEpoch }}
 OperatorPrivateKey: "{{ .OperatorPrivateKey }}"
 SSVAPIPort: {{ .SSVAPIPort }}
 Exporter: "{{ .Exporter }}"

--- a/nodes/ssv/node.star
+++ b/nodes/ssv/node.star
@@ -16,7 +16,9 @@ def generate_config(
         operator_private_key,
         enr,
         is_exporter,
+        args,
 ):
+    boole_epoch = args.get("boole_epoch", 1 << 63)
     discovery = ""
     if enr == "":
         discovery = "mdns"
@@ -41,7 +43,8 @@ def generate_config(
         Exporter=is_exporter,
         SSVAPIPort=SSV_API_PORT,
         MetricsAPIPort=SSV_METRICS_PORT,
-        EnableTraces=True
+        EnableTraces=True,
+        BooleEpoch=boole_epoch,
     )
 
     plan.print(

--- a/params.yaml
+++ b/params.yaml
@@ -44,6 +44,9 @@ network:
 monitor:
   enabled: false
 
+# Boole fork activation epoch (shared by both SSV and Anchor nodes)
+boole_epoch: 3
+
 nodes:
   ssv:
     count: 2

--- a/params.yaml
+++ b/params.yaml
@@ -39,7 +39,7 @@ network:
 
   port_publisher:
     cl:
-      enabled: true
+      enabled: false
 
 monitor:
   enabled: false


### PR DESCRIPTION
## Summary
- Disable port publishing (not needed for CI, prevents port conflicts)
- Add kurtosis cleanup to run targets to ensure clean state

This fixes the CI port binding error:
```
failed to bind host port for 0.0.0.0:33008:172.16.0.13:4000/tcp: address already in use
```