### PR TITLE
chore: fix fork casing and network name for interop

### DIFF
--- a/nodes/anchor/config/ssv_network_name.txt
+++ b/nodes/anchor/config/ssv_network_name.txt
@@ -1,1 +1,1 @@
-kurtosis
+testnet

--- a/nodes/ssv/config.yml.tmpl
+++ b/nodes/ssv/config.yml.tmpl
@@ -19,8 +19,8 @@ ssv:
     RegistryContractAddr: "{{ .RegistryContractAddr }}"
     DiscoveryProtocolID: "{{ .DiscoveryProtocolID }}"
     Forks:
-      gaslimit36: 0
-      boole: {{ .BooleEpoch }}
+      GasLimit36: 0
+      Boole: {{ .BooleEpoch }}
 OperatorPrivateKey: "{{ .OperatorPrivateKey }}"
 SSVAPIPort: {{ .SSVAPIPort }}
 Exporter: "{{ .Exporter }}"


### PR DESCRIPTION
## Changes
Network name: Anchor uses ssv_network_name.txt to build Boole gossipsub topics (/ssv/{name}/boole/{subnet}). SSV Go nodes derive testnet from their local-testnet  network config. With Anchor set to kurtosis, the two implementations end up on different topics and can't exchange messages

Also updated the SSVForks name format per https://github.com/ssvlabs/ssv-mini/pull/25#discussion_r2770336220

Note that `nodes/anchor/config/ssv_fork_schedule.yaml` has to be set to `domain_type: 00000000` atm if testing the boole fork network topology transition since ssv logic currently doesn't allow for the domain type to update dynamically at a certain epoch just yet. They're working on that part, so I'm optimistically not modifying `ssv_fork_schedule.ymal` here, just an fyi for local testing